### PR TITLE
Allow building on macOS as well as Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Support compiling on/for macOS
+
 ## [v0.1.3] - 2023-03-26
 
 - Fix huge memory usage when many files

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,10 @@ use clap::Parser;
 use std::borrow::Cow;
 use std::fs::File;
 use std::io::{Read, Write};
+#[cfg(target_os = "linux")]
 use std::os::linux::fs::MetadataExt;
+#[cfg(target_os = "macos")]
+use std::os::macos::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use svd_parser::svd::{BitRange, Field};
 


### PR DESCRIPTION
Just a tiny patch to allow building for macOS, by changing which `MetadataExt` trait gets imported based on `#[cfg(target_os)]`